### PR TITLE
fix: enforce CRLF in ESLint/Prettier config

### DIFF
--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -28,7 +28,9 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/no-unsafe-argument': 'warn'
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      'linebreak-style': ['error', 'windows'],
+      'prettier/prettier': ['error', { endOfLine: 'crlf' }],
     },
   },
 );


### PR DESCRIPTION
This PR fixes issue #3 by updating ESLint/Prettier rules to enforce CRLF line endings on Windows.
- Added `linebreak-style: windows`
- Configured `prettier/prettier` endOfLine to `crlf`

Closes #3