### PR TITLE
Add pgAdmin service with environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,35 @@ npx prisma migrate dev --name init
 # Generate Prisma client
 
 npx prisma generate
+
+### pgAdmin (Database UI)
+
+Access: http://localhost:5050
+
+Login credentials come from `.env.local`:
+
+- Email: value of `PGADMIN_DEFAULT_EMAIL`
+- Password: value of `PGADMIN_DEFAULT_PASSWORD`
+
+Preconfigured server: A connection named "Local Postgres" should appear automatically (loaded from `pgadmin-servers.json`).
+
+If it does not appear, add it manually:
+
+1. Right‑click "Servers" → Register → Server.
+2. General tab → Name: Local Postgres (any name you like).
+3. Connection tab:
+
+- Host: `postgres` (container hostname on the Docker network)
+- Port: `5432`
+- Maintenance DB: `postgres` (or your DB name)
+- Username: value of `POSTGRES_USER`
+- Password: value of `POSTGRES_PASSWORD` (tick "Save password").
+
+4. Save.
+
+Troubleshooting:
+
+- Wrong login: verify `.env.local` values and recreate pgAdmin container (`docker compose down pgadmin && docker compose up -d pgadmin`).
+- Connection refused: ensure the Postgres container is running: `docker ps` should list it as Up.
+- Env vars not applied: ensure `env_file: - .env.local` exists for the pgAdmin service and you did not override them with empty `${VAR}` entries.
+- Inspect container env: `docker exec sport-archive-pgadmin-1 env | findstr PGADMIN`.

--- a/docker.compose.local.yml
+++ b/docker.compose.local.yml
@@ -8,5 +8,17 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    restart: always
+    env_file:
+      - .env.local
+    ports:
+      - "5050:80"
+    depends_on:
+      - postgres
+    volumes:
+      - ./pgadmin-servers.json:/pgadmin4/servers.json
+
 volumes:
   postgres_data:

--- a/pgadmin-servers.json
+++ b/pgadmin-servers.json
@@ -1,0 +1,13 @@
+{
+  "Servers": {
+    "Local Postgres": {
+      "Name": "Local Postgres",
+      "Group": "Servers",
+      "Host": "postgres",
+      "Port": 5432,
+      "MaintenanceDB": "postgres",
+      "Username": "postgres",
+      "SSLMode": "prefer"
+    }
+  }
+}


### PR DESCRIPTION
Added pgadmin service in docker-compose.local.yml
Configured environment variables PGADMIN_DEFAULT_EMAIL and PGADMIN_DEFAULT_PASSWORD via .env.local
Updated README with instructions on accessing pgAdmin

Closes #7