### PR TITLE
feat(sports): add CRUD for Sport with validation and Swagger docs

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.2.0",
         "@prisma/client": "^6.14.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
@@ -2061,6 +2062,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2435,6 +2442,39 @@
         "typescript": ">=4.8.2"
       }
     },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.0.tgz",
+      "integrity": "sha512-5wolt8GmpNcrQv34tIPUtPoV1EeFbCetm40Ij3+M0FNNnf2RJ3FyWfuQvI8SBlcJyfaounYVTKzKHreFXsUyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.2.0",
+        "swagger-ui-dist": "5.21.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.6",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.6.tgz",
@@ -2648,6 +2688,13 @@
       "dependencies": {
         "@prisma/debug": "6.14.0"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.40",
@@ -3989,7 +4036,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -7427,7 +7473,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7606,7 +7651,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -9470,6 +9514,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
+      "integrity": "sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,8 +11,11 @@
       "dependencies": {
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
+        "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/platform-express": "^11.0.1",
         "@prisma/client": "^6.14.0",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.2",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
       },
@@ -2374,6 +2377,26 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.6",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.6.tgz",
@@ -2993,6 +3016,12 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.2",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.2.tgz",
+      "integrity": "sha512-y7pa/oEJJ4iGYBxOpfAKn5b9+xuihvzDVnC/OSvlVnGxVg0pOqmjiMafiJ1KVNQEaPZf9HsEp5icEwGg8uIe5Q==",
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -4464,6 +4493,23 @@
       "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT"
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.2.tgz",
+      "integrity": "sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.9.0"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -7498,6 +7544,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.14",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.14.tgz",
+      "integrity": "sha512-HBAMAV7f3yGYy7ZZN5FxQ1tXJTwC77G5/96Yn/SH/HPyKX2EMLGFuCIYUmdLU7CxxJlQcvJymP/PGLzyapurhQ==",
+      "license": "MIT"
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -10175,6 +10227,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.2.0",
     "@prisma/client": "^6.14.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,8 +22,11 @@
   "dependencies": {
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
+    "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/client": "^6.14.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaModule } from './prisma/prisma.module';
+import { SportsModule } from './sports/sports.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, SportsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,10 +1,19 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+
+  const config = new DocumentBuilder()
+    .setTitle('Sports API')
+    .setVersion('1.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
+
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/backend/src/sports/dto/create-sport.dto.ts
+++ b/backend/src/sports/dto/create-sport.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateSportDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+}

--- a/backend/src/sports/dto/update-sport.dto.ts
+++ b/backend/src/sports/dto/update-sport.dto.ts
@@ -1,0 +1,9 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSportDto } from './create-sport.dto';
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateSportDto extends PartialType(CreateSportDto) {
+  @IsString()
+  @IsOptional()
+  name?: string;
+}

--- a/backend/src/sports/sports.controller.ts
+++ b/backend/src/sports/sports.controller.ts
@@ -1,0 +1,41 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { SportsService } from './sports.service';
+import { CreateSportDto } from './dto/create-sport.dto';
+import { UpdateSportDto } from './dto/update-sport.dto';
+
+@Controller('sports')
+export class SportsController {
+  constructor(private readonly sportsService: SportsService) {}
+
+  @Get()
+  findAll() {
+    return this.sportsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.sportsService.findOne(id);
+  }
+  @Post()
+  create(@Body() createSportDto: CreateSportDto) {
+    return this.sportsService.create(createSportDto);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateSportDto: UpdateSportDto) {
+    return this.sportsService.update(id, updateSportDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.sportsService.remove(id);
+  }
+}

--- a/backend/src/sports/sports.controller.ts
+++ b/backend/src/sports/sports.controller.ts
@@ -10,31 +10,67 @@ import {
 import { SportsService } from './sports.service';
 import { CreateSportDto } from './dto/create-sport.dto';
 import { UpdateSportDto } from './dto/update-sport.dto';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('sports')
 @Controller('sports')
 export class SportsController {
   constructor(private readonly sportsService: SportsService) {}
 
   @Get()
+  @ApiOperation({
+    summary: 'List all sports',
+    description: 'Returns all sports ordered by name.',
+  })
+  @ApiResponse({ status: 200, description: 'List of sports returned.' })
   findAll() {
     return this.sportsService.findAll();
   }
 
   @Get(':id')
+  @ApiOperation({
+    summary: 'Get a sport by id',
+    description: 'Returns a sport by its id.',
+  })
+  @ApiParam({ name: 'id', description: 'Sport ID (cuid string)' })
+  @ApiResponse({ status: 200, description: 'Sport returned.' })
+  @ApiResponse({ status: 404, description: 'Sport not found.' })
   findOne(@Param('id') id: string) {
     return this.sportsService.findOne(id);
   }
+
   @Post()
+  @ApiOperation({
+    summary: 'Create a sport',
+    description: 'Creates a new sport with the given name.',
+  })
+  @ApiResponse({ status: 201, description: 'Sport created.' })
+  @ApiResponse({ status: 409, description: 'Sport name already exists.' })
   create(@Body() createSportDto: CreateSportDto) {
     return this.sportsService.create(createSportDto);
   }
 
   @Patch(':id')
+  @ApiOperation({
+    summary: 'Update a sport',
+    description: 'Updates a sport by its id with the given name.',
+  })
+  @ApiParam({ name: 'id', description: 'Sport ID (cuid string)' })
+  @ApiResponse({ status: 200, description: 'Sport updated.' })
+  @ApiResponse({ status: 404, description: 'Sport not found.' })
+  @ApiResponse({ status: 409, description: 'Sport name already exists.' })
   update(@Param('id') id: string, @Body() updateSportDto: UpdateSportDto) {
     return this.sportsService.update(id, updateSportDto);
   }
 
   @Delete(':id')
+  @ApiOperation({
+    summary: 'Delete a sport',
+    description: 'Deletes a sport by its id.',
+  })
+  @ApiParam({ name: 'id', description: 'Sport ID (cuid string)' })
+  @ApiResponse({ status: 200, description: 'Sport deleted.' })
+  @ApiResponse({ status: 404, description: 'Sport not found.' })
   remove(@Param('id') id: string) {
     return this.sportsService.remove(id);
   }

--- a/backend/src/sports/sports.controller.ts
+++ b/backend/src/sports/sports.controller.ts
@@ -12,7 +12,7 @@ import { CreateSportDto } from './dto/create-sport.dto';
 import { UpdateSportDto } from './dto/update-sport.dto';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 
-@ApiTags('sports')
+@ApiTags('Sports')
 @Controller('sports')
 export class SportsController {
   constructor(private readonly sportsService: SportsService) {}

--- a/backend/src/sports/sports.module.ts
+++ b/backend/src/sports/sports.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SportsService } from './sports.service';
+import { SportsController } from './sports.controller';
+
+@Module({
+  controllers: [SportsController],
+  providers: [SportsService],
+  exports: [SportsService],
+})
+export class SportsModule {}

--- a/backend/src/sports/sports.service.ts
+++ b/backend/src/sports/sports.service.ts
@@ -14,10 +14,12 @@ export class SportsService {
 
   async create(dto: CreateSportDto) {
     const name = dto.name.trim();
+
     const existing = await this.prisma.sport.findFirst({
       where: { name: { equals: name, mode: 'insensitive' } },
       select: { id: true },
     });
+
     if (existing) {
       throw new ConflictException('Sport name already exists');
     }
@@ -32,6 +34,7 @@ export class SportsService {
     const sport = await this.prisma.sport.findUnique({
       where: { id },
     });
+
     if (!sport) {
       throw new NotFoundException('Sport not found');
     }
@@ -39,14 +42,16 @@ export class SportsService {
   }
 
   async update(id: string, dto: UpdateSportDto) {
-    await this.ensureExists(id);
     const data: Prisma.SportUpdateInput = {};
+
     if (dto.name !== undefined) {
       const trimmed = dto.name.trim();
+
       const dup = await this.prisma.sport.findFirst({
         where: { name: { equals: trimmed, mode: 'insensitive' }, NOT: { id } },
         select: { id: true },
       });
+
       if (dup) {
         throw new ConflictException('Sport name already exists');
       }
@@ -56,16 +61,7 @@ export class SportsService {
   }
 
   async remove(id: string) {
-    await this.ensureExists(id);
     await this.prisma.sport.delete({ where: { id } });
     return { id, deleted: true };
-  }
-
-  private async ensureExists(id: string) {
-    const exists = await this.prisma.sport.findUnique({
-      where: { id },
-      select: { id: true },
-    });
-    if (!exists) throw new NotFoundException('Sport not found');
   }
 }

--- a/backend/src/sports/sports.service.ts
+++ b/backend/src/sports/sports.service.ts
@@ -1,0 +1,75 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { CreateSportDto } from './dto/create-sport.dto';
+import { UpdateSportDto } from './dto/update-sport.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { Prisma } from 'generated/prisma';
+
+@Injectable()
+export class SportsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(dto: CreateSportDto) {
+    const name = dto.name.trim();
+    try {
+      return await this.prisma.sport.create({ data: { name } });
+    } catch (e) {
+      if (this.isUnique(e))
+        throw new ConflictException('Sport name already exists');
+      throw e;
+    }
+  }
+
+  findAll() {
+    return this.prisma.sport.findMany({ orderBy: { name: 'asc' } });
+  }
+
+  async findOne(id: string) {
+    const sport = await this.prisma.sport.findUnique({
+      where: { id },
+    });
+    if (!sport) {
+      throw new NotFoundException('Sport not found');
+    }
+    return sport;
+  }
+
+  async update(id: string, dto: UpdateSportDto) {
+    await this.ensureExists(id);
+    const data: Prisma.SportUpdateInput = {};
+    if (dto.name !== undefined) data.name = dto.name.trim();
+    try {
+      return await this.prisma.sport.update({ where: { id }, data });
+    } catch (e) {
+      if (this.isUnique(e))
+        throw new ConflictException('Sport name already exists');
+      throw e;
+    }
+  }
+
+  async remove(id: string) {
+    await this.ensureExists(id);
+    await this.prisma.sport.delete({ where: { id } });
+    return { id, deleted: true };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.sport.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    if (!exists) throw new NotFoundException('Sport not found');
+  }
+
+  private isUnique(e: unknown): boolean {
+    return (
+      typeof e === 'object' &&
+      e !== null &&
+      'code' in e &&
+      (e as { code?: unknown }).code === 'P2002'
+    );
+  }
+}


### PR DESCRIPTION
Closes #12 

Adds full CRUD for Sport entity using NestJS + Prisma  with Swagger docs and robust error handling.

Endpoints: POST /sports, GET /sports, GET /sports/:id, PATCH /sports/:id, DELETE /sports/:id

DTO validation (class-validator / class-transformer) with trimming

Duplicate handling: app-level case-insensitive checks for name on create/update (no DB unique index required)

Service implements unique name conflict handling and not-found checks

Added/update PrismaService usage and SportsModule wiring in AppModule

Global ValidationPipe (whitelist + transform) setup

Error responses: 400 invalid payload, 404 not found, 409 duplicate