### PR TITLE
feat(scraper): add scraper service and store scrapped news to database

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,10 +13,12 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^6.0.0",
         "@nestjs/swagger": "^11.2.0",
         "@prisma/client": "^6.14.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "playwright": "^1.55.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
       },
@@ -2425,6 +2427,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.0.0.tgz",
+      "integrity": "sha512-aQySMw6tw2nhitELXd3EiRacQRgzUKD9mFcUZVOJ7jPLqIBvXOyvRWLsK9SdurGA+jjziAlMef7iB5ZEFFoQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.3.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.7",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.7.tgz",
@@ -2970,6 +2985,12 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
       "license": "MIT"
     },
     "node_modules/@types/methods": {
@@ -4907,6 +4928,19 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.0.tgz",
+      "integrity": "sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7694,6 +7728,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -8538,6 +8581,50 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,10 +24,12 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.0.0",
     "@nestjs/swagger": "^11.2.0",
     "@prisma/client": "^6.14.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "playwright": "^1.55.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { NationalTeamsModule } from './national-teams/national-teams.module';
 import { CompetitionsModule } from './competitions/competitions.module';
 import { ContentTypesModule } from './content-types/content-types.module';
 import { RecordsModule } from './records/records.module';
+import { CronModule } from './chron/chron.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { RecordsModule } from './records/records.module';
     CompetitionsModule,
     ContentTypesModule,
     RecordsModule,
+    CronModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/chron/chron.module.ts
+++ b/backend/src/chron/chron.module.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
+import { PrismaService } from '../prisma/prisma.service';
+import { MediaJobService } from './media-job/media-job.service';
+
+@Module({
+  imports: [ScheduleModule.forRoot()],
+  providers: [MediaJobService, PrismaService],
+})
+export class CronModule {}

--- a/backend/src/chron/media-job/media-job.service.ts
+++ b/backend/src/chron/media-job/media-job.service.ts
@@ -1,0 +1,170 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Browser, chromium } from 'playwright';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { Article, MediaSource } from 'src/utils/interfaces';
+import {
+  _24SATA,
+  FETCHING_COUNT,
+  GERMANIJAK,
+  GOL_HR,
+  INDEX_HR,
+  SN,
+} from '../../utils/constants';
+import { fetch24SataArticles } from './scrapers/24sata-scraper';
+import { fetchGermanijakArticles } from './scrapers/germanijak-scraper';
+import { fetchGolHrArticles } from './scrapers/golhr-scraper';
+import { fetchIndexArticles } from './scrapers/index-scraper';
+import { fetchSnArticles } from './scrapers/sn-scraper';
+
+@Injectable()
+export class MediaJobService {
+  private browser: Browser;
+  private isRunning = false;
+
+  constructor(private readonly prismaService: PrismaService) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async handleCron() {
+    console.log('=== CRON JOB TRIGGERED ===', new Date().toISOString());
+    if (this.isRunning) {
+      console.log('Previous job still running, skipping this execution');
+      return;
+    }
+
+    try {
+      this.isRunning = true;
+      console.log('Media job started.');
+
+      const mediaSources = await this.prismaService.mediaSource.findMany();
+      console.log(`Found ${mediaSources.length} media sources in database`);
+      console.log('Media sources:', mediaSources);
+
+      if (mediaSources.length === 0) {
+        console.log(
+          'No media sources found in database! Please add some media sources first.',
+        );
+        return;
+      }
+      for (const mediaSource of mediaSources) {
+        console.log(`Fetching articles for ${mediaSource.name}`);
+        await this.fetchArticles(mediaSource);
+        console.log('Finished fetching articles for: ', mediaSource.name);
+      }
+
+      console.log('Media job finished.');
+    } catch (error) {
+      console.error('Error in cron job:', error);
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  async fetchArticles(mediaSource: MediaSource) {
+    console.log('Fetching articles for: ', mediaSource.name);
+    this.browser = await chromium.launch({ headless: true });
+
+    const page = await this.browser.newPage({
+      screen: { width: 430, height: 1000 },
+    });
+
+    const url = `${mediaSource.baseUrl}/${mediaSource.urlPath ? mediaSource.urlPath : ''}`;
+
+    console.log('Navigating to: ', url);
+
+    await page.goto(url, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await page.waitForTimeout(3000);
+
+    let articles: Article[] = [];
+
+    switch (mediaSource.name) {
+      case INDEX_HR:
+        articles = await fetchIndexArticles(
+          this.browser,
+          mediaSource.baseUrl,
+          url,
+          page,
+        );
+        break;
+      case _24SATA:
+        articles = await fetch24SataArticles(page);
+        break;
+      case SN:
+        articles = await fetchSnArticles(page);
+        break;
+      case GOL_HR:
+        articles = await fetchGolHrArticles(this.browser, url, page);
+        break;
+      case GERMANIJAK:
+        articles = await fetchGermanijakArticles(page);
+        break;
+    }
+
+    console.log(`Scraped ${articles.length} articles before filtering`);
+    articles = articles.slice(0, FETCHING_COUNT);
+    console.log(`Processing ${articles.length} articles after filtering`);
+
+    if (articles.length === 0) {
+      console.log('No articles found to process');
+      await page.close();
+      this.browser.close();
+      return;
+    }
+
+    try {
+      const testCount = await this.prismaService.mediaNews.count();
+      console.log(`Current articles in database: ${testCount}`);
+    } catch (error) {
+      console.error('Database connection test failed:', error);
+    }
+
+    articles = articles.slice(0, FETCHING_COUNT);
+
+    for (const article of articles) {
+      try {
+        await this.prismaService.mediaNews.upsert({
+          where: {
+            externalId_mediaSourceId: {
+              externalId: article.externalId,
+              mediaSourceId: mediaSource.id,
+            },
+          },
+          create: {
+            title: article.title,
+            content: article.content,
+            urlPath: `${mediaSource.baseUrl}${article.urlPath}`,
+            externalId: article.externalId,
+            mediaSourceId: mediaSource.id,
+            likeCount: article.likeCount,
+            shareCount: article.shareCount,
+            commentCount: article.commentCount,
+            totalEngagements: article.totalEngagements,
+          },
+          update: {
+            likeCount: article.likeCount,
+            shareCount: article.shareCount,
+            commentCount: article.commentCount,
+            totalEngagements: article.totalEngagements,
+          },
+        });
+        console.log(`Successfully upserted article: ${article.title}`);
+      } catch (error: unknown) {
+        console.log('Prisma error while upserting article:');
+        console.log(error);
+        console.error(`Failed to upsert article: ${article.title}`);
+      }
+    }
+
+    console.log(`Fetched ${articles.length} articles for ${mediaSource.name}`);
+
+    await page.close();
+    this.browser.close();
+  }
+}

--- a/backend/src/chron/media-job/scrapers/24sata-scraper.ts
+++ b/backend/src/chron/media-job/scrapers/24sata-scraper.ts
@@ -1,0 +1,60 @@
+import { Page } from 'playwright';
+import { Article } from 'src/utils/interfaces';
+
+export const fetch24SataArticles = async (page: Page): Promise<Article[]> => {
+  // Handle cookie consent popup if it appears
+  try {
+    const acceptButton = await page.waitForSelector(
+      '#didomi-notice-agree-button',
+      {
+        timeout: 5000,
+      },
+    );
+    if (acceptButton) {
+      await acceptButton.click();
+      // Wait a bit for the popup to disappear
+      await page.waitForTimeout(1000);
+    }
+  } catch (e: unknown) {
+    // Cookie popup might not appear if already accepted
+    console.log(e, 'No cookie popup found or already accepted');
+  }
+
+  return await page.evaluate(() => {
+    const articles = Array.from(document.querySelectorAll('.article_wrap'));
+
+    return articles.map((article) => {
+      const cardElement = article.querySelector('.card');
+      const titleElement = article.querySelector('.card__title');
+      const labelElement = article.querySelector('.card__label');
+      const linkElement = article.querySelector('.card__link');
+
+      // Get engagement counts
+      const totalReactionsElement = article.querySelector(
+        '.engagement_bar__meta_item--reaction .total-count',
+      );
+      const commentsElement = article.querySelector(
+        '.engagement_bar__meta_item--comment .engagement_bar__meta_item--count',
+      );
+
+      const externalId = cardElement?.getAttribute('data-article-id') || '';
+      const totalReactions = totalReactionsElement
+        ? parseInt(totalReactionsElement.textContent.trim() || '0', 10) || 0
+        : 0;
+      const commentCount = commentsElement
+        ? parseInt(commentsElement.textContent.trim() || '0', 10) || 0
+        : 0;
+
+      return {
+        title: titleElement ? titleElement.textContent.trim() || '' : '',
+        content: labelElement ? labelElement.textContent.trim() || '' : '',
+        urlPath: linkElement ? linkElement.getAttribute('href') || '' : '',
+        externalId,
+        likeCount: totalReactions,
+        shareCount: 0,
+        commentCount,
+        totalEngagements: totalReactions + commentCount,
+      };
+    });
+  });
+};

--- a/backend/src/chron/media-job/scrapers/germanijak-scraper.ts
+++ b/backend/src/chron/media-job/scrapers/germanijak-scraper.ts
@@ -1,0 +1,29 @@
+import { Page } from 'playwright';
+import { Article } from 'src/utils/interfaces';
+
+export const fetchGermanijakArticles = async (
+  page: Page,
+): Promise<Article[]> => {
+  // Get all articles from the main page
+  const articles: Article[] = await page.evaluate(() => {
+    const items = Array.from(document.querySelectorAll('a')).filter((e) => {
+      const href = e.getAttribute('href');
+      const title = e.getAttribute('title');
+      return href?.includes('/nogomet/vijesti/') && !!title;
+    });
+
+    return items.map((element) => ({
+      title: element.getAttribute('title') || '',
+      content: '', // No content since we're not visiting individual articles
+      urlPath: element.getAttribute('href') || '',
+      externalId:
+        element.getAttribute('href')?.split('/').pop()?.split('.')[0] || '',
+      likeCount: 0,
+      shareCount: 0,
+      commentCount: 0,
+      totalEngagements: 0,
+    }));
+  });
+
+  return articles;
+};

--- a/backend/src/chron/media-job/scrapers/golhr-scraper.ts
+++ b/backend/src/chron/media-job/scrapers/golhr-scraper.ts
@@ -1,0 +1,76 @@
+import { Browser, Page } from 'playwright';
+import { Article } from 'src/utils/interfaces';
+
+export const fetchGolHrArticles = async (
+  browser: Browser,
+  url: string,
+  page: Page,
+): Promise<Article[]> => {
+  // First get all articles from the main page
+  const articles: Article[] = await page.evaluate(() => {
+    const items = Array.from(document.querySelectorAll('article'));
+    return items
+      .filter((item) => item.getAttribute('data-ga4-category') === 'nogomet')
+      .map((item) => {
+        const tagElement = item.querySelector('.subtitle');
+        const titleElement = item.querySelector('.title');
+        const title =
+          tagElement && titleElement
+            ? `${tagElement.innerHTML.toUpperCase()} ${titleElement.innerHTML.replace(/[\r\n]+/g, '').trim()}`
+            : '';
+        const urlElement = item.querySelector('a');
+        const externalId = item.getAttribute('data-ga4-article-id') || '';
+
+        return {
+          title,
+          content: '',
+          urlPath: urlElement ? urlElement.getAttribute('href') || '' : '',
+          externalId,
+          likeCount: 0,
+          shareCount: 0,
+          commentCount: 0,
+          totalEngagements: 0,
+        };
+      });
+  });
+
+  // Then visit each article and get its share count
+  const articlesWithShares: Article[] = [];
+  for (const article of articles) {
+    try {
+      await page.goto(url + article.urlPath, {
+        waitUntil: 'domcontentloaded',
+      });
+
+      // Wait for the Facebook share iframe to load
+      await page.waitForSelector(
+        'iframe[title="fb:share_button Facebook Social Plugin"]',
+      );
+
+      // Get the frame
+      const fbFrame = page.frameLocator(
+        'iframe[title="fb:share_button Facebook Social Plugin"]',
+      );
+
+      // Wait for the share count element and get its text
+      const shareCount = await fbFrame
+        .locator('span._5n6h')
+        .first()
+        .evaluate((el: HTMLElement) => parseInt(el.textContent || '0', 10));
+
+      articlesWithShares.push({
+        ...article,
+        shareCount,
+        totalEngagements: shareCount,
+      });
+    } catch (error: unknown) {
+      console.error(
+        `Error fetching share count for article: ${article.urlPath}`,
+        error,
+      );
+      articlesWithShares.push(article); // Keep the article even if share count fails
+    }
+  }
+
+  return articlesWithShares;
+};

--- a/backend/src/chron/media-job/scrapers/index-scraper.ts
+++ b/backend/src/chron/media-job/scrapers/index-scraper.ts
@@ -1,0 +1,159 @@
+import { Browser, Page } from 'playwright';
+import { Article } from 'src/utils/interfaces';
+
+export const fetchIndexArticles = async (
+  browser: Browser,
+  baseUrl: string,
+  url: string,
+  page: Page,
+): Promise<Article[]> => {
+  // First get all articles from the main page
+  const articles: Article[] = await page.evaluate(() => {
+    const firstNewsHolder = document.querySelector('.first-news-holder');
+    const titleElement = firstNewsHolder?.querySelector('.title');
+    const summaryElement = firstNewsHolder?.querySelector('.summary');
+    const linkElement = firstNewsHolder?.querySelector('a');
+    const externalId = linkElement
+      ? linkElement.href.split('/').pop()?.split('.')[0] || ''
+      : '';
+
+    const firstArticle = {
+      title: titleElement ? titleElement.innerHTML : '',
+      content: summaryElement ? summaryElement.innerHTML : '',
+      urlPath: linkElement ? linkElement.getAttribute('href') || '' : '',
+      externalId,
+      likeCount: 0,
+      shareCount: 0,
+      commentCount: 0,
+      totalEngagements: 0,
+    };
+
+    // Limit the number of grid items to fetch
+    const items = Array.from(document.querySelectorAll('.grid-item')).slice(
+      0,
+      9,
+    ); // 9 + 1 first article = 10 total
+
+    const nextArticles = items.map((item) => {
+      const titleElement = item.querySelector('.title');
+      const summaryElement = item.querySelector('.summary');
+      const linkElement = item.querySelector('a');
+      const externalId = linkElement
+        ? linkElement.href.split('/').pop()?.split('.')[0] || ''
+        : '';
+
+      return {
+        title: titleElement ? titleElement.innerHTML : '',
+        content: summaryElement ? summaryElement.innerHTML : '',
+        urlPath: linkElement ? linkElement.getAttribute('href') || '' : '',
+        externalId,
+        likeCount: 0,
+        shareCount: 0,
+        commentCount: 0,
+        totalEngagements: 0,
+      };
+    });
+
+    return [firstArticle, ...nextArticles];
+  });
+
+  console.log(`Found ${articles.length} articles on main page`);
+
+  const validArticles = articles.filter(
+    (article) => article.urlPath && article.externalId && article.title,
+  );
+
+  console.log(`${validArticles.length} valid articles after filtering`);
+
+  // Then visit each article and get its comment count
+  const articlesWithComments: Article[] = [];
+  for (const article of validArticles) {
+    console.log('Articles for scan count:', articles.length);
+    try {
+      // Construct proper URL - check if urlPath is already full URL or relative
+      const articleUrl = article.urlPath.startsWith('http')
+        ? article.urlPath
+        : `${baseUrl}${article.urlPath}`;
+
+      console.log(`Fetching comments for article: ${articleUrl}`);
+
+      await page.goto(articleUrl, {
+        waitUntil: 'domcontentloaded',
+        timeout: 8000,
+      });
+
+      // Handle cookie consent popup if it appears
+      try {
+        const acceptButton = await page.waitForSelector(
+          '#didomi-notice-agree-button',
+          {
+            timeout: 3000,
+          },
+        );
+        if (acceptButton) {
+          await acceptButton.click();
+          // Wait a bit for the popup to disappear
+          await page.waitForTimeout(1000);
+        }
+      } catch (error) {
+        // Cookie popup might not appear if already accepted
+        console.log(error, 'No cookie popup found or already accepted');
+      }
+
+      let commentCount = 0;
+      try {
+        // Wait for comments container to be in the DOM
+        await page.waitForSelector('#comments-container', { timeout: 10000 });
+
+        // Scroll to the comments container
+        await page.evaluate(async () => {
+          const commentsContainer = document.querySelector(
+            '#comments-container',
+          );
+          if (commentsContainer) {
+            commentsContainer.scrollIntoView({
+              behavior: 'smooth',
+              block: 'center',
+            });
+            // Additional wait to ensure content loads
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+          }
+        });
+
+        // Now try to get the comment count
+        const count = await page.evaluate(() => {
+          const totalCountElement = document.querySelector('.total-count');
+          if (totalCountElement) {
+            const countText = totalCountElement.textContent;
+            const match = countText.match(/\((\d+)\)/);
+            return match ? parseInt(match[1]) : 0;
+          }
+          return 0;
+        });
+
+        commentCount = count;
+        console.log(
+          `Found comment count: ${commentCount} for article: ${article.title}`,
+        );
+      } catch (error: unknown) {
+        console.log('Failed to get comments, using count 0:', error);
+      }
+
+      articlesWithComments.push({
+        ...article,
+        commentCount,
+        totalEngagements: commentCount,
+      });
+    } catch (error: unknown) {
+      console.error(
+        `Error fetching comment count for article: ${article.urlPath}`,
+        error,
+      );
+      articlesWithComments.push(article);
+    }
+  }
+  console.log(
+    `Processed ${articlesWithComments.length} articles with comments`,
+  );
+  return articlesWithComments;
+};

--- a/backend/src/chron/media-job/scrapers/sn-scraper.ts
+++ b/backend/src/chron/media-job/scrapers/sn-scraper.ts
@@ -1,0 +1,31 @@
+import { Page } from 'playwright';
+import { Article } from 'src/utils/interfaces';
+
+export const fetchSnArticles = async (page: Page): Promise<Article[]> => {
+  //comments available
+  return await page.evaluate(() => {
+    const items = Array.from(document.querySelectorAll('article'));
+    return items.map((item) => {
+      const tagElement = item.querySelector('.card__egida');
+      const titleElement = item.querySelector('.card__title ');
+      const title =
+        tagElement && titleElement
+          ? `${tagElement.innerHTML} ${titleElement.innerHTML.replace(/[\r\n]+/g, '').trim()}`
+          : '';
+      const contentElement = item.querySelector('.card__subtitle');
+      const urlElement = item.querySelector('a');
+      const externalId = item.getAttribute('data-upscore-object-id') || '';
+
+      return {
+        title,
+        content: contentElement ? contentElement.innerHTML : '',
+        urlPath: urlElement ? urlElement.getAttribute('href') || '' : '',
+        externalId,
+        likeCount: 0,
+        shareCount: 0,
+        commentCount: 0,
+        totalEngagements: 0,
+      };
+    });
+  });
+};

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -1,0 +1,6 @@
+export const FETCHING_COUNT = 10;
+export const INDEX_HR = 'index.hr';
+export const _24SATA = '24sata';
+export const SN = 'Sportske Novosti';
+export const GOL_HR = 'gol.hr';
+export const GERMANIJAK = 'Germanijak';

--- a/backend/src/utils/interfaces.ts
+++ b/backend/src/utils/interfaces.ts
@@ -1,0 +1,19 @@
+export interface Article {
+  title: string;
+  content: string;
+  urlPath: string;
+  externalId: string;
+  likeCount: number;
+  shareCount: number;
+  commentCount: number;
+  totalEngagements: number;
+}
+
+export interface MediaSource {
+  id: string;
+  baseUrl: string;
+  urlPath?: string | null;
+  name: string;
+  createdAt: Date;
+  updatedAt: Date;
+}


### PR DESCRIPTION
Closes #19 

- Scrape content every 5 minutes to ensure fresh, up-to-date sports news
- Collect article titles, content, engagement metrics (likes, shares, comments), and metadata
-  Index.hr, 24sata.hr, Sportnet.hr, Gol.hr, Germanijak.hr
- Uses upsert method that can create/update depending on existing data